### PR TITLE
ISSUE-54: push ubuntu docker image to dockerhub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,7 @@ on:
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: ibmcloud-image-builder
+  IMAGE_NAME_UBUNTU: ibmcloud-image-builder-ubuntu
 
 jobs:
   # Run tests.
@@ -96,6 +97,46 @@ jobs:
       - name: Push image
         run: |
           IMAGE_ID=syibm/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+
+  # Push Ubuntu 20.04 image to DockerHub
+  # See also https://docs.docker.com/docker-hub/builds/
+  push-dockerhub-ubuntu:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile.ubuntu --tag $IMAGE_NAME_UBUNTU
+
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u syibm --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=syibm/$IMAGE_NAME_UBUNTU
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -77,16 +77,16 @@ RUN set -ex && \
     rm terraform_0.12.29_linux_amd64.zip && \
     sudo mv terraform /usr/local/bin && \
     # ibm provider
-    wget https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.11.0/linux_amd64.zip && \
+    wget https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v1.11.1/linux_amd64.zip && \
     unzip linux_amd64.zip && \
     chmod +x terraform-provider-ibm_* && \
     sudo mv terraform-provider-ibm_* /usr/local/bin && \
     rm linux_amd64.zip && \
     # packer
-    wget https://releases.hashicorp.com/packer/1.6.0/packer_1.6.0_linux_amd64.zip && \
-    unzip packer_1.6.0_linux_amd64.zip && \
+    wget https://releases.hashicorp.com/packer/1.6.1/packer_1.6.1_linux_amd64.zip && \
+    unzip packer_1.6.1_linux_amd64.zip && \
     chmod +x packer && \
-    rm packer_1.6.0_linux_amd64.zip && \
+    rm packer_1.6.1_linux_amd64.zip && \
     sudo mv packer /usr/local/bin && \
     # vault
     wget https://releases.hashicorp.com/vault/1.4.2/vault_1.4.2_linux_amd64.zip && \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ## Docker image naming; overridable by environment
 IMAGE_NAME ?= ibmcloud-image-builder
+IMAGE_NAME_UBUNTU ?= ibmcloud-image-builder-ubuntu
 IMAGE_VERSION_LATEST ?= latest
 REMOTE_BRANCH ?= master
 
@@ -12,7 +13,7 @@ build:
 	docker build . -f Dockerfile -t $(IMAGE_NAME):$(IMAGE_VERSION_LATEST)
 
 ubuntu-build:
-	docker build . -f Dockerfile.ubuntu -t $(IMAGE_NAME)-ubuntu:$(IMAGE_VERSION_LATEST)
+	docker build . -f Dockerfile.ubuntu -t $(IMAGE_NAME_UBUNTU):$(IMAGE_VERSION_LATEST)
 
 build-images:
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/ubuntu/bionic/base   "

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The building time of this Docker image is < 1 min, I guess it can be used as an 
 * graphviz 2.42
 * noweb 2.11b
 
-The building time of this Ubuntu Docker image is > 10 mins from my machines, it takes very long. While preparing a repository in docker hub, maybe worthy to try once. It won't be changed very often any more.
+The building time of this Ubuntu Docker image is > 10 mins from my machines, it takes very long. While preparing a repository in docker hub, maybe worthy to try once. It won't be changed very often any more. This Ubuntu Docker image assumes that you are running the Docker container from a Ubuntu host by default. You can change the `docker-compose.yml` file
+to run this Docker image from another host OS flavor.
 
 # Available images
 

--- a/cloud.env
+++ b/cloud.env
@@ -4,7 +4,7 @@ export IBMCLOUD_API_ENDPOINT="https://cloud.ibm.com"
 export IBMCLOUD_IAM_API_ENDPOINT="https://iam.cloud.ibm.com"
 export IBMCLOUD_RESOURCE_CATALOG_API_ENDPOINT="https://globalcatalog.cloud.ibm.com"
 export IBMCLOUD_RESOURCE_MANAGEMENT_API_ENDPOINT="https://resource-controller.cloud.ibm.com"
-
+export IBMCLOUD_RESOURCE_CONTROLLER_API_ENDPOINT="https://resource-controller.cloud.ibm.com"
 
 export IBMCLOUD_GT_API_ENDPOINT="https://tags.global-search-tagging.cloud.ibm.com"
 export COS_STATE_ACCESS_KEY_ID=$COS_STATE_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary
 This PR is to resolve the issue : [issue-54](https://github.com/IBM-Cloud/ibmcloud-image-builder/issues/54)

## Description

Push Ubuntu 20.04 docker image to dockerhub
This PR requires some tests with tagging/release. I'm going to merge by myself not to bother @zgrossbart .

## Tests

- [x] Travis CI
