### PR TITLE
ISSUE-60: ENV GOPATH

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -63,9 +63,12 @@ RUN set -ex && \
     wget https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz && \
     sudo tar xzf go1.13.9.linux-amd64.tar.gz && \
     rm go1.13.9.linux-amd64.tar.gz && \
-    sudo mv go /usr/local/go-1.13
+    sudo mv go /usr/local/go-1.13 && \
+    mkdir -p ${HOME}/go && \
+    sudo chown ${USER_UID}:${USER_GID} ${HOME}/go
 
 ENV GOROOT=/usr/local/go-1.13
+ENV GOPATH=${HOME}/go
 ENV PATH=$GOROOT/bin:${HOME}/go/bin:$PATH
 
     # terraform


### PR DESCRIPTION
## Summary
 This PR is to resolve the issue : [issue-60](https://github.com/IBM-Cloud/ibmcloud-image-builder/issues/60)

## Description

Add the missing env variable `GOPATH` into `Dockerfile.ubuntu`

## Tests

- [x] Travis CI
