### PR TITLE
ISSUE-39: Parallel image build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,15 @@ lauguage: minimal
 service:
   - docker
 
+env:
+  jobs:
+    - DISTRO_NAME=ubuntu DISTRO_VERSION=bionic TYPE=base
+    - DISTRO_NAME=ubuntu DISTRO_VERSION=bionic TYPE=docker
+    - DISTRO_NAME=centos DISTRO_VERSION=7 TYPE=base
+    - DISTRO_NAME=centos DISTRO_VERSION=7 TYPE=docker
+
+before_script:
+  - make prep-builder
+
 scripts:
-  - make all
+  - make build-image

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 IMAGE_NAME ?= ibmcloud-image-builder
 IMAGE_NAME_UBUNTU ?= ibmcloud-image-builder-ubuntu
 IMAGE_VERSION_LATEST ?= latest
-REMOTE_BRANCH ?= master
+REMOTE_BRANCH ?= main
 
 ## Options
 default: all
 
-all: build build-images cleanup
+all: build build-all cleanup
 
 build:
 	docker build . -f Dockerfile -t $(IMAGE_NAME):$(IMAGE_VERSION_LATEST)
@@ -15,7 +15,7 @@ build:
 ubuntu-build:
 	docker build . -f Dockerfile.ubuntu -t $(IMAGE_NAME_UBUNTU):$(IMAGE_VERSION_LATEST)
 
-build-images:
+build-all:
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/ubuntu/bionic/base   "
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/ubuntu/bionic/docker "
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/centos/7/base        "
@@ -42,5 +42,12 @@ centos-7-base:
 centos-7-docker:
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/centos/7/docker      "
 	docker run --privileged -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-delete.sh packer/centos/7/docker     "
+
+build-image:
+	$(if $(DISTRO_NAME),,$(error DISTRO_NAME is not set. [ubuntu, centos]))
+	$(if $(DISTRO_VERSION),,$(error DISTRO_VERSION is not set.[bionic (ubuntu), 7 (centos)]))
+	$(if $(TYPE),,$(error TYPE is not set. [base, docker]))
+	docker run --privileged --rm -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-build.sh packer/${DISTRO_NAME}/${DISTRO_VERSION}/${TYPE}"
+	docker run --privileged --rm -v `pwd`:/ibmcloud-image-builder ${IMAGE_NAME}:${IMAGE_VERSION_LATEST} /bin/bash -c "./packer-delete.sh packer/${DISTRO_NAME}/${DISTRO_VERSION}/${TYPE}"
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ REMOTE_BRANCH ?= main
 ## Options
 default: all
 
-all: build build-all cleanup
+all: pre-builder build-all cleanup
 
-build:
+prep-builder:
 	docker build . -f Dockerfile -t $(IMAGE_NAME):$(IMAGE_VERSION_LATEST)
 
 ubuntu-build:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone git@github.com:IBM-Cloud/ibmcloud-image-builder.git
 cd ibmcloud-image-builder
 docker pull syibm/ibmcloud-image-builder
 docker tag  syibm/ibmcloud-image-builder ibmcloud-image-builder
-make build-images
+make build-all
 ```
 
 
@@ -133,15 +133,15 @@ $ git clone git@github.com:IBM-Cloud/ibmcloud-image-builder.git
 $ cd ibmcloud-image-builder
 $ docker pull syibm/ibmcloud-image-builder
 $ docker tag  syibm/ibmcloud-image-builder ibmcloud-image-builder
-$ make build-images
+$ make build-all
 ```
 
-Or we can build the docker image(`make build`) locally as below:
+Or we can build the docker image(`make prep-builder`) locally as below:
 ```
 $ git clone git@github.com:IBM-Cloud/ibmcloud-image-builder.git
 $ cd ibmcloud-image-builder
-$ make build
-$ make build-images
+$ make prep-builder
+$ make build-all
 ```
 
 Note: If a new packer template needs to be created, then please repeat yourself.


### PR DESCRIPTION
## Summary
Resolves #39 

## Description
- Add environment variables to set each parallel job
- Add generic `build-image` make target.
- Rename `prep-builder` make target to be more clear.

## Tests
- [x] Travis CI
